### PR TITLE
Small changes

### DIFF
--- a/ComfyGray.css
+++ b/ComfyGray.css
@@ -566,6 +566,9 @@
 	display: none;
 }
 
+.channelTextAreaDisabled-1p2fQv + .typing-2J1mQU {
+	display: none;
+}
 
 /* bubble messages */
 .cozyMessage-1DWF9U .contents-2MsGLg>.markup-eYLPri:not(:empty) {

--- a/ComfyGray.css
+++ b/ComfyGray.css
@@ -2247,6 +2247,9 @@ button.button-2b4VEQ.height20-WSMpPs.button-f2h6uQ.lookFilled-yCfaCM.colorGreen-
 	max-width: 100%;
 	right: 0px;
 	top: 0px;
+	margin-right: 20px;
+	margin-top: 15px;
+	margin-bottom: -25px;
 }
 
 .customStatus-3XAoF9 {


### PR DESCRIPTION
- channelTextAreaDisabled fix
Previously css deleted only channelTextAreaDisabled, so channel's "Slow mode" message still could be seen

- profileBadges change
Small relocation of profileBadges, so it doesn't look like not modified by css place